### PR TITLE
chore: set GUSINFO to Lightning Data Service / LDS Core

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # Comment line immediately above ownership line is reserved for related other information. Please be careful while editing.
 #ECCN:Open Source
-#GUSINFO:Open Source,Open Source Workflow
+#GUSINFO:Lightning Data Service,LDS Core


### PR DESCRIPTION
## Summary

Update CODEOWNERS `#GUSINFO:` line to point to the actual owning GUS Scrum Team and Product Tag, per OSPO compliance request.

- **Scrum Team:** Lightning Data Service (Active in GUS)
- **Product Tag:** LDS Core (Active in GUS)

Previous value (`Open Source,Open Source Workflow`) was flagged as invalid by OSPO — those are placeholders, not real GUS records for this repo.

## Context

Email from Jim Jagielski (Head of OSPO), 2026-07-23: OSPO FY27 compliance sweep flagged `forcedotcom/state-management` as missing a valid GUS Scrum Team and Product Tag. Format required per https://github.com/salesforce/oss-template/blob/main/CODEOWNERS.

## Test plan

- [ ] Confirm Scrum Team + Product Tag match the maintainer's intent
- [ ] OSPO compliance rechecks the repo